### PR TITLE
[22111138 오원창] 회원가입과 로그인의 순서, 종료 오류 수정

### DIFF
--- a/main.py
+++ b/main.py
@@ -1278,9 +1278,9 @@ while user == 0: #유저 입력할때 까지 무한루프 도는 인터페이스
     interface = input("로그인 기능 입력 (? 입력시 도움말) : ")
 
     if interface == "1":
-        user = Login_interface()#유저 상태를 user 변수에 저장 - 이후 기능 사용시 user에 해당하는 자료에서 산출
+        user = user_reg_include_name_phone() #회원가입 함수
     elif interface == "2":
-        user_reg_include_name_phone() #회원가입 함수 - 이미 존재
+        user = Login_interface() #로그인함수
     elif interface == "3":
         find_id_by_phone() #id 찾기 - 이미 존재
     elif interface == "4": 
@@ -1311,7 +1311,7 @@ while not b_is_exit:
         analyze_categories()
     elif func == "?":
         print_help()
-    elif func == "exit" or func == "x":
+    elif func == "exit" or func == "x" or func == "종료":
         print("프로그램을 종료합니다.")
         b_is_exit = True
     elif func == "메모장":


### PR DESCRIPTION
1번이 회원가입 2번이 로그인으로 표시되어 있는데 실행을 해보면 반대로 되어 있어서 이를 수정하였고
프로그램 종료를 하고 싶을 때 exit 나 x 가 아닌 종료를 입력해도 프로그램을 종료할 수 있도록 수정하였습니다.