### PR TITLE
[22112110 김성민] 약속 관리에 대한 여러가지 기능 추가

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import hashlib #hashlib 사용
 import os
 import json
-from datetime import datetime, date
+from datetime import datetime, date, timedelta
 import pickle
 import Account_book
 import random
@@ -16,10 +16,28 @@ import simulation
 import visualizer
 import points_system  # 포인트 시스템 추가
 import portfolio_management
+import threading
 
 
 # 약속을 담을 리스트
 appointments = []
+
+# 약속 알림을 처리할 함수
+def appointment_reminder(appointment, reminder_time):
+    """
+    약속 시작 시간 전에 알림을 보내는 함수.
+
+    :param appointment: 알림을 보낼 약속 정보가 담긴 딕셔너리
+    :param reminder_time: 약속 시작 시간 몇 분 전에 알림을 보낼지 (분 단위)
+    """
+    start_time = appointment["start_date"]
+    alert_time = start_time - timedelta(minutes=reminder_time)
+    now = datetime.now()
+    wait_time = (alert_time - now).total_seconds()
+
+    if wait_time > 0:
+        time.sleep(wait_time)
+        print(f"알림: {appointment['name']} 약속이 {reminder_time}분 후에 시작됩니다.")
 
 def add_appointment():
         """
@@ -29,6 +47,8 @@ def add_appointment():
         start_date = datetime.strptime(input("시작 일자 (YYYY-MM-DD): "), '%Y-%m-%d')
         end_date = datetime.strptime(input("종료 일자 (YYYY-MM-DD): "), '%Y-%m-%d')
         budget = float(input("예산: "))
+
+        reminder_time = int(input("약속 시작 시간 몇 분 전에 알려드릴까요?(분): "))
 
         # 새 약속이 기존 약속들과 시간 충돌하는지 체크
         if not is_time_conflict(start_date, end_date):
@@ -41,6 +61,12 @@ def add_appointment():
             }
             appointments.append(appointment)
             print(f"약속 '{name}'이(가) 추가되었습니다.")
+
+             # 약속 알림 스레드 생성 및 시작
+            reminder_thread = threading.Thread(target=appointment_reminder, args=(appointment, reminder_time))
+            reminder_thread.daemon = True  # 프로그램 종료 시 스레드도 종료되도록 설정
+            reminder_thread.start()
+
         else:
             print("약속 간에 시간이 겹칩니다.")
 

--- a/main.py
+++ b/main.py
@@ -22,48 +22,45 @@ import portfolio_management
 appointments = []
 
 def add_appointment():
-    """
-    약속을 추가하는 함수.
-    """
+        """
+        약속을 추가하는 함수.
+        """
+        name = input("약속 이름: ")
+        start_date = datetime.strptime(input("시작 일자 (YYYY-MM-DD): "), '%Y-%m-%d')
+        end_date = datetime.strptime(input("종료 일자 (YYYY-MM-DD): "), '%Y-%m-%d')
+        budget = float(input("예산: "))
 
-    name = input("약속 이름: ")
-    start_date = datetime.strptime(input("시작 일자 (YYYY-MM-DD): "), '%Y-%m-%d')
-    end_date = datetime.strptime(input("종료 일자 (YYYY-MM-DD): "), '%Y-%m-%d')
-    budget = float(input("예산: "))
+        # 새 약속이 기존 약속들과 시간 충돌하는지 체크
+        if not is_time_conflict(start_date, end_date):
+            appointment = {
+                "name": name,
+                "start_date": start_date,
+                "end_date": end_date,
+                "budget": budget,
+                "expenses": []  # 약속 내에 사용한 지출을 확인하기 위한 리스트
+            }
+            appointments.append(appointment)
+            print(f"약속 '{name}'이(가) 추가되었습니다.")
+        else:
+            print("약속 간에 시간이 겹칩니다.")
 
-    appointment = {
-        "name": name,
-        "start_date": start_date,
-        "end_date": end_date,
-        "budget": budget,
-        "expenses": []  # 약속 내에 사용한 지출을 확인하기 위한 리스트
-    }
-    appointments.append(appointment)
-    print(f"약속 '{name}'이(가) 추가되었습니다.")
+def is_time_conflict(new_start, new_end):
+        """
+        새로운 약속의 시작 시간과 종료 시간이 기존 약속들과 충돌하는지 검사합니다.
 
-def add_expense():
-    """
-    약속 중 지출을 설정하기 위한 함수
-    """
+        :param new_start: 새로운 약속의 시작 시간
+        :param new_end: 새로운 약속의 종료 시간
+        :return: 시간 충돌이 있으면 True, 없으면 False
+        """
+        for appointment in appointments:
+            # 새로운 약속의 시작 시간이 기존 약속의 기간 안에 있거나,
+            # 새로운 약속의 종료 시간이 기존 약속의 기간 안에 있는 경우 충돌로 간주합니다.
+            if (appointment["start_date"] <= new_start <= appointment["end_date"]) or \
+               (appointment["start_date"] <= new_end <= appointment["end_date"]) or \
+               (new_start <= appointment["start_date"] and new_end >= appointment["end_date"]):
+                return True
+        return False
 
-    name = input("약속 이름: ")
-    for appointment in appointments:
-        if appointment["name"] == name:
-            date = datetime.strptime(input("지출 일자 (YYYY-MM-DD): "), '%Y-%m-%d')
-            description = input("지출 설명: ")
-            amount = float(input("지출 금액: "))
-
-            if appointment["start_date"] <= date <= appointment["end_date"]:
-                appointment["expenses"].append({"date": date, "description": description, "amount": amount})
-                total_expenses = sum(expense["amount"] for expense in appointment["expenses"])
-                if total_expenses > appointment["budget"]:
-                    print(f"경고: 예산 초과! 현재 지출: {total_expenses}, 예산: {appointment['budget']}")
-                else:
-                    print(f"지출이 추가되었습니다. 현재 지출: {total_expenses}, 예산: {appointment['budget']}")
-            else:
-                print("지출 일자가 약속 기간 내에 있지 않습니다.")
-            return
-    print("해당 이름의 약속이 존재하지 않습니다.")
 
 def show_appointments():
     """
@@ -74,11 +71,7 @@ def show_appointments():
         print(f"시작 일자: {appointment['start_date'].strftime('%Y-%m-%d')}")
         print(f"종료 일자: {appointment['end_date'].strftime('%Y-%m-%d')}")
         print(f"예산: {appointment['budget']}")
-        print("지출 내역:")
-        total_expenses = sum(expense["amount"] for expense in appointment["expenses"])
-        print(f"  * 약속 내 총 지출 : {total_expenses}")
-        for expense in appointment["expenses"]:
-            print(f"  - 일자: {expense['date'].strftime('%Y-%m-%d')}, 설명: {expense['description']}, 금액: {expense['amount']}")
+        
 
 def appointment_management():
     while True:
@@ -88,16 +81,13 @@ def appointment_management():
         if choice == '1':
             add_appointment()
         elif choice == '2':
-            add_expense()
-        elif choice == '3':
             show_appointments()
         elif choice == '0':
             print("메인 메뉴로 돌아갑니다. \n")
             break
         elif choice == '?':
             print("1. 약속 추가")
-            print("2. 지출 추가")
-            print("3. 약속 보기")
+            print("2. 약속 보기")
             print("0. 메인 메뉴로 돌아가기")
         else:
             print("잘못된 선택입니다. 다시 시도하세요.")
@@ -1214,6 +1204,7 @@ def print_help():
     3: 월별 보고서 생성
     4: 예산 설정 및 초과 알림
     5: 지출 카테고리 분석
+    6: 약속 관리
     ?: 도움말 출력
     exit: 종료
     """)
@@ -2330,6 +2321,8 @@ while not b_is_exit:
         set_budget()
     elif func == "5":
         analyze_categories()
+    elif func == "6":
+        appointment_management()
     elif func == "?":
         print_help()
     elif func == "exit" or func == "x" or func =="종료":

--- a/main.py
+++ b/main.py
@@ -73,6 +73,52 @@ def show_appointments():
         print(f"예산: {appointment['budget']}")
         
 
+def delete_appointment():
+    """
+    약속을 삭제하는 함수
+    """
+    name = input("삭제할 약속 이름: ")
+    for appointment in appointments:
+        if appointment["name"] == name:
+            appointments.remove(appointment)
+            print(f"약속 '{name}'이(가) 삭제되었습니다.")
+            return
+    print(f"약속 '{name}'을(를) 찾을 수 없습니다.")
+
+def edit_appointment():
+    """
+    약속을 수정하는 함수
+    """
+    name = input("수정할 약속 이름: ")
+    for appointment in appointments:
+        if appointment["name"] == name:
+            while True:
+                try:
+                    new_start_date = datetime.strptime(input("새 시작 일자 (YYYY-MM-DD): "), '%Y-%m-%d')
+                    break
+                except ValueError:
+                    print("잘못된 날짜 형식입니다. YYYY-MM-DD 형식으로 다시 입력해주세요.")
+
+            while True:
+                try:
+                    new_end_date = datetime.strptime(input("새 종료 일자 (YYYY-MM-DD): "), '%Y-%m-%d')
+                    break
+                except ValueError:
+                    print("잘못된 날짜 형식입니다. YYYY-MM-DD 형식으로 다시 입력해주세요.")
+
+            new_budget = float(input("새 예산: "))
+
+            if not is_time_conflict(new_start_date, new_end_date):
+                appointment["start_date"] = new_start_date
+                appointment["end_date"] = new_end_date
+                appointment["budget"] = new_budget
+                print(f"약속 '{name}'이(가) 수정되었습니다.")
+            else:
+                print("약속 간에 시간이 겹칩니다.")
+            return
+    print(f"약속 '{name}'을(를) 찾을 수 없습니다.")
+       
+
 def appointment_management():
     while True:
         print("\n---- 약속 관리 메뉴----")
@@ -82,12 +128,18 @@ def appointment_management():
             add_appointment()
         elif choice == '2':
             show_appointments()
+        elif choice == '3':
+            delete_appointment()
+        elif choice == '4':
+            edit_appointment()
         elif choice == '0':
             print("메인 메뉴로 돌아갑니다. \n")
             break
         elif choice == '?':
             print("1. 약속 추가")
             print("2. 약속 보기")
+            print("3. 약속 삭제")
+            print("4. 약속 수정")
             print("0. 메인 메뉴로 돌아가기")
         else:
             print("잘못된 선택입니다. 다시 시도하세요.")


### PR DESCRIPTION
1.  약속에 관한 전반적인 기능만 appointment_management 함수에서 다루도록 지출 내역 관련 함수를 삭제하고 약속을 추가하는 함수에 추가한 약속이 기존의 약속과 일정이 겹치는 경우 "약속 간에 시간이 겹칩니다"를 표시하고 다시 일정을 정하는 기능 추가
그리고 도움말 항목과 메인 루프에 약속 관리에 관한 설명과 함수 추가.

2. 약속 관리 함수 내에 약속을 삭제하는 함수와 약속 일정과 예산을 수정하는 함수 추가.

3. 사용자가 지정한 약속 시간의 몇 분 전에 알림을 보낼지 입력 받고 별도의 스레드를 생성하여 이 스레드를 데몬 스레드로 설정, 메인 프로그램이 종료될 때 약속 알림 스레드도 자동으로 종료되지만 appointment_reminder 함수가 별도의 실행 흐름에서 실행되기 시작, 약속 시간 전 알람을 받을 수 있는 기능 추가.